### PR TITLE
Update pom.xml and add settings.xml with recommended gpg management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 
 # maven
 target/
-.mvn/settings.xml
 
 # MacOS
 .DS_Store

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,17 @@
+<settings>
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>sign</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
+</settings>

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -7,42 +7,25 @@ This guide is for maintainers of the regola project only.
 - Have release access to sonatype for `com.adobe.abp`
 - `brew install gpg` (follow the [sonatype guide](https://central.sonatype.org/publish/requirements/gpg/))
     - You will need to upload your public key to a keyserver with:
-```sh
-gpg --keyserver <server> --send-keys  <key_id_from: gpg --list-keys>
+  ```sh
+  gpg --keyserver <server> --send-keys  <key_id_from: gpg --list-keys>
+  
+  # Run the command above for each of the following servers (some may not respond):
+  - keys.openpgp.org
+  - keyserver.ubuntu.com
+  - pgp.mit.edu
+  ```
 
-# List of keyservers to try:
-- keys.openpgp.org
-- keyserver.ubuntu.com
-- pgp.mit.edu
-```
+  - Example: `gpg --keyserver keyserver.ubuntu.com --send-keys 9ADC71851C6B40511143070F3912D719680E00000`
+- Generate a [User Access Token](https://central.sonatype.org/publish/generate-token/)
+- Store your sonatype username and password as environment variables:
+  ```sh
+  export SONATYPE_USERNAME=<your_sonatype_username>
+  export SONATYPE_PASSWORD=<your_sonatype_password>
+  ```
 
-- Generate an [User Access Token](https://central.sonatype.org/publish/generate-token/)
-- Create a `settings.xml` file under the `.mvn` folder with the following:
-
-```xml
-<settings>
-    <servers>
-        <server>
-            <id>ossrh</id>
-            <username>your_sonatype_username</username>
-            <password>your_sonatype_access_token</password>
-        </server>
-    </servers>
-    <profiles>
-        <profile>
-            <id>sign</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <gpg.passphrase>your_gpg_passphrase</gpg.passphrase>
-            </properties>
-        </profile>
-    </profiles>
-</settings>
-```
-
-**Note**: never share passwords or passphrases in git.
+> [!IMPORTANT]
+> Remember to never share passwords or passphrases in git!
 
 ### Pre-Merge Checks
 
@@ -79,7 +62,7 @@ To produce a release you should:
 This will:
 - Drop the `-SNAPSHOT` qualifier from the version number
 - Create a tag in git
-- Push the commit and tag to Github
+- Push the commit and tag to GitHub
 - Publish the artifacts to the maven central repository
 - Increase the version number and add the SNAPSHOT qualifier
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>${maven.gpg.plugin.version}</version>
                 <configuration>
+                    <useAgent>true</useAgent>
                     <gpgArguments>
                         <arg>--pinentry-mode</arg>
                         <arg>loopback</arg>
@@ -169,9 +170,12 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <compilerVersion>${maven.compiler.version}</compilerVersion>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
+                    <compilerArgs>
+                        <arg>-Xlint:deprecation</arg>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Update pom.xml and add settings.xml with recommended gpg management

## Description

<!--- Describe your changes in detail -->
1. Add settings.xml for all developers to be able to run project
2. Update pom.xml to use gpg key without using clear test passwords
3. Update DEPLOY.md to reflect these changes

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Use recommended mechanism to manage gpg keys and deploy changes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Signing with gpg key has been verified with `mvn verify`.
Deployment workflow will be tested after merge.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
