### PR TITLE
Fix compile warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <commons.lang3.version>3.19.0</commons.lang3.version>
         <commons.math3.version>3.6.1</commons.math3.version>
         <jackson.version>2.20.0</jackson.version>
+        <jackson-annotations.version>2.20</jackson-annotations.version>
         <caffeine.version>3.2.2</caffeine.version>
         <fburato.functional.utils.core.version>1.0.0</fburato.functional.utils.core.version>
 
@@ -218,7 +219,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/src/main/java/com/adobe/abp/regola/rules/StringRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/StringRule.java
@@ -46,17 +46,17 @@ public class StringRule extends SingleValueRule<String> {
             case EQUALS:
                 return checkFact(fact, String::equals);
             case GREATER_THAN:
-                return checkFact(fact, (f, value) -> StringUtils.compare(f, value) > 0);
+                return checkFact(fact, (f, value) -> StringUtils.compare(f, value, true) > 0);
             case GREATER_THAN_EQUAL:
-                return checkFact(fact, (f, value) -> StringUtils.compare(f, value) >= 0);
+                return checkFact(fact, (f, value) -> StringUtils.compare(f, value, true) >= 0);
             case LESS_THAN:
-                return checkFact(fact, (f, value) -> StringUtils.compare(f, value) < 0);
+                return checkFact(fact, (f, value) -> StringUtils.compare(f, value, true) < 0);
             case LESS_THAN_EQUAL:
-                return checkFact(fact, (f, value) -> StringUtils.compare(f, value) <= 0);
+                return checkFact(fact, (f, value) -> StringUtils.compare(f, value, true) <= 0);
             case STARTS_WITH:
-                return checkFact(fact, StringUtils::startsWith);
+                return checkFact(fact, String::startsWith);
             case ENDS_WITH:
-                return checkFact(fact, StringUtils::endsWith);
+                return checkFact(fact, String::endsWith);
             default:
                 return Result.OPERATION_NOT_SUPPORTED;
         }


### PR DESCRIPTION
* Fix error with jackson-annotation version 2.20.0, as this is not present in maven central at this time
* Remove use of deprecated methods in StringRule