### PR TITLE
Remove use of synchronized, addressing thread-safety concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # regola
 
 [![Maven Central](https://img.shields.io/badge/Maven%20Central-latest-blue)](https://central.sonatype.com/artifact/com.adobe.abp/regola)
+[![CI](https://github.com/adobe/regola/actions/workflows/ci.yml/badge.svg)](https://github.com/adobe/regola/actions/workflows/ci.yml)
 
 **regola** is a rule evaluator written in Java.
 
@@ -121,6 +122,8 @@ where all the rules must evaluate to VALID for it to evaluate to VALID.
 
 The AND rule is commutative: `A && B = B && A`.
 
+An empty `AND` evaluates to `VALID`. This follows the identity of conjunction: with no subrules, there is nothing to invalidate the expression.
+
 #### Or Rule
 
 The "Or Rule" is used to combine multiple rules together, 
@@ -145,6 +148,8 @@ So, for example: `FAILED || INVALID == FAILED`, while `MAYBE || INVALID == INVAL
 
 The OR rule is commutative: `A || B = B || A`.
 
+An empty `OR` evaluates to `INVALID`. This follows the identity of disjunction: with no subrules, there is nothing that can make the expression valid.
+
 #### Not Rule
 
 The "Not Rule" is used to negate the result of another rule.
@@ -165,6 +170,8 @@ The "Not Rule" is used to negate the result of another rule.
 | MAYBE                   | MAYBE                   |
 | FAILED                  | FAILED                  |
 | OPERATION_NOT_SUPPORTED | OPERATION_NOT_SUPPORTED |
+
+A `NOT` rule must contain a non-null `rule`. If the operand is missing, the evaluation is treated as malformed configuration and fails.
 
 ### Fact-only Rules
 
@@ -431,6 +438,14 @@ Rules can be combined using the boolean rules: AND, OR, NOT.
 #### Ignoring results
 
 Rules can be set to be ignored, so that the evaluation of AND/OR/NOT rules does not take them into account.
+
+This matters for empty or effectively-empty boolean rules too:
+
+- `AND` with no subrules evaluates to `VALID`.
+- `OR` with no subrules evaluates to `INVALID`.
+- `OR` where every subrule is present but marked as `ignored` evaluates to `VALID`, because all configured subrules are excluded from the final decision.
+- `NOT` with an ignored subrule evaluates to `VALID`.
+- `NOT` with no subrule fails.
 
 Example of a rule marked as `ignored`:
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Maven compile settings -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
@@ -170,8 +169,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.release}</release>
                     <showWarnings>true</showWarnings>
                     <failOnError>true</failOnError>
                     <failOnWarning>true</failOnWarning>

--- a/src/main/java/com/adobe/abp/regola/json/RuleDeserializer.java
+++ b/src/main/java/com/adobe/abp/regola/json/RuleDeserializer.java
@@ -20,12 +20,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 public class RuleDeserializer extends StdDeserializer<Rule> {
     private static final long serialVersionUID = -5996525917304371916L;
 
-    private final Map<String, Class<? extends Rule>> registry = new HashMap<>();
+    private final HashMap<String, Class<? extends Rule>> registry = new HashMap<>();
 
     RuleDeserializer() {
         super(Rule.class);

--- a/src/main/java/com/adobe/abp/regola/json/RuleModule.java
+++ b/src/main/java/com/adobe/abp/regola/json/RuleModule.java
@@ -40,6 +40,7 @@ public class RuleModule extends SimpleModule {
             .registerRule("NULL", NullRule.class)
             .registerRule("CONSTANT", ConstantRule.class);
 
+    @SuppressWarnings("this-escape")
     public RuleModule() {
         super("RuleModule");
         addDeserializer(Rule.class, deserializers);

--- a/src/main/java/com/adobe/abp/regola/json/RuleResultModule.java
+++ b/src/main/java/com/adobe/abp/regola/json/RuleResultModule.java
@@ -18,6 +18,7 @@ public class RuleResultModule extends SimpleModule {
 
     private static final long serialVersionUID = -8895061058178793722L;
 
+    @SuppressWarnings("this-escape")
     public RuleResultModule() {
         super("RuleResultModule");
         addDeserializer(RuleResult.class, new RuleResultDeserializer());

--- a/src/main/java/com/adobe/abp/regola/rules/AndRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/AndRule.java
@@ -18,16 +18,16 @@ import com.adobe.abp.regola.results.RuleResult;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
  * This rule evaluates to true if all the subrules evaluate to true.
  * If a subrule is ignored, it is not taken into account for the final result.
  * Short-circuiting: as soon as one of the subrules evaluates to not-VALID, the evaluation stops and the result is not-VALID.
+ * An empty AND has no operands to falsify the conjunction, so it evaluates to VALID (the identity element).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@SuppressWarnings("this-escape")
 public class AndRule extends MultiaryBooleanRule {
 
     public AndRule() {
@@ -41,59 +41,72 @@ public class AndRule extends MultiaryBooleanRule {
 
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
-        return new EvaluationResult() {
+        return new LockingEvaluationResult() {
 
-            private Result result = Result.MAYBE;
-            private final CompletableFuture<Result> status = new CompletableFuture<>();
-            private final AtomicInteger rulesToEvaluate = new AtomicInteger(getRules().size());
-            private List<EvaluationResult> results = List.of();
+            // Number of subrules still to report back. Accessed only inside decideUnderLock (under the lock).
+            private int rulesToEvaluate = getRules().size();
+
+            // Child results, published once in startEvaluation() before any callback is wired up.
+            private volatile List<EvaluationResult> results = List.of();
+
+            @Override
+            protected void startEvaluation() {
+                final List<Rule> rules = getRules();
+                final List<EvaluationResult> evaluated = rules.stream()
+                        .map(rule -> rule.evaluate(factsResolver))
+                        .collect(Collectors.toList());
+                results = evaluated; // safe publication before the callbacks below can fire
+
+                if (rules.isEmpty()) {
+                    complete(Result.VALID); // empty conjunction is the identity ⇒ VALID
+                    return;
+                }
+
+                // Non-blocking: status() kicks off each subrule and whenComplete only registers a callback,
+                // so the subrules evaluate concurrently. Each callback reports back via evaluateSubresult as
+                // it settles; this loop does not wait. (Actual concurrency depends on the fact fetchers being async.)
+                for (int i = 0; i < rules.size(); i++) {
+                    final boolean ignore = rules.get(i).isIgnore();
+                    evaluated.get(i).status()
+                            .whenComplete((subresult, throwable) -> evaluateSubresult(subresult, throwable, ignore));
+                }
+            }
+
+            private void evaluateSubresult(Result subresult, Throwable throwable, boolean ignore) {
+                if (!ignore && throwable != null) {
+                    completeExceptionally(throwable);
+                    return;
+                }
+                decideUnderLock(() -> {
+                    rulesToEvaluate--;
+                    if (!ignore && subresult != Result.VALID) {
+                        return Optional.of(subresult); // short-circuit: a non-VALID subrule fails the AND
+                    } else if (rulesToEvaluate == 0) {
+                        return Optional.of(Result.VALID); // every subrule evaluated (or was ignored) ⇒ VALID
+                    }
+                    return Optional.empty();
+                });
+            }
+
+            @Override
+            protected void afterCompletion(Result completedResult, Throwable throwable) {
+                Optional.ofNullable(getAction())
+                        .ifPresent(action -> action.onCompletion(completedResult, throwable, snapshot()));
+            }
 
             @Override
             public RuleResult snapshot() {
+                final List<EvaluationResult> capturedResults = results;
+                final Result capturedResult = getResult();
                 return MultiaryBooleanRuleResult.builder().with(r -> {
                     r.type = getType();
                     r.description = getDescription();
-                    r.result = result;
-                    r.rules = results.stream()
+                    r.result = capturedResult;
+                    r.rules = capturedResults.stream()
                             .map(EvaluationResult::snapshot)
                             .collect(Collectors.toSet());
                     r.ignored = isIgnore();
                 }).build();
-            }
-
-            @Override
-            public CompletableFuture<Result> status() {
-                results = getRules().stream()
-                        .map(this::evaluateRule)
-                        .collect(Collectors.toList());
-                return status
-                        .whenComplete((result, throwable) -> Optional.ofNullable(getAction())
-                                .ifPresent(action -> action.onCompletion(result, throwable, snapshot())));
-            }
-
-            private EvaluationResult evaluateRule(Rule rule) {
-                final var evaluationResult = rule.evaluate(factsResolver);
-                evaluationResult.status()
-                        .whenComplete((result, throwable) -> evaluateSubresult(result, throwable, rule.isIgnore()));
-                return evaluationResult;
-            }
-
-            private synchronized void evaluateSubresult(Result subresult, Throwable throwable, boolean ignore) {
-                final var remaining = rulesToEvaluate.decrementAndGet();
-                if (!status.isDone()) {
-                    if (!ignore && throwable != null) {
-                        result = Result.FAILED;
-                        status.completeExceptionally(throwable);
-                    } else {
-                        if (!ignore && subresult != Result.VALID) {
-                            result = subresult;
-                            status.complete(result);
-                        } else if (remaining == 0) {
-                            result = Result.VALID;
-                            status.complete(result);
-                        }
-                    }
-                }
             }
         };
     }

--- a/src/main/java/com/adobe/abp/regola/rules/DateRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/DateRule.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executor;
 /**
  * A rule that checks if a fact is a date and compares it to a value.
  */
+@SuppressWarnings("this-escape")
 public class DateRule extends SingleValueRule<OffsetDateTime> {
 
     public DateRule() {

--- a/src/main/java/com/adobe/abp/regola/rules/ExistsRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/ExistsRule.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executor;
  * A rule that checks if a fact exists or not (it is null).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@SuppressWarnings("this-escape")
 public class ExistsRule extends KeyBasedRule {
 
     private final Executor executor;

--- a/src/main/java/com/adobe/abp/regola/rules/LockingEvaluationResult.java
+++ b/src/main/java/com/adobe/abp/regola/rules/LockingEvaluationResult.java
@@ -1,0 +1,257 @@
+/*
+ *  Copyright 2026 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License
+ */
+
+package com.adobe.abp.regola.rules;
+
+import com.adobe.abp.regola.actions.Action;
+import com.adobe.abp.regola.results.Result;
+import com.adobe.abp.regola.results.RuleResult;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+/**
+ * Base class for {@link EvaluationResult} implementations that need thread-safe state mutation
+ * from concurrent {@link CompletableFuture} callbacks.
+ *
+ * <p>The class guarantees three non-obvious properties:
+ * <ul>
+ *   <li>{@link #startEvaluation()} runs at most once, on the first {@link #status()} call</li>
+ *   <li>the published {@link Result} and the terminal status future never diverge</li>
+ *   <li>{@link #afterCompletion(Result, Throwable)} runs outside the lock but before the future resolves</li>
+ * </ul>
+ *
+ * <p>If {@code afterCompletion} throws, the future still transitions. A callback failure replaces a
+ * normal completion, while an already-failed evaluation keeps its original cause and may record the
+ * callback failure as suppressed.
+ */
+public abstract class LockingEvaluationResult implements EvaluationResult {
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    // volatile so an external thread polling snapshot() without the lock still observes a published
+    // value. All in-lock writes already establish happens-before; volatile covers stray external pollers.
+    private volatile Result result = Result.MAYBE;
+
+    private final CompletableFuture<Result> status = new CompletableFuture<>();
+
+    // Guards one-time startup. Written under the lock.
+    private boolean started;
+
+    // Marks that a terminal decision has been made. Flipped false→true exactly once, under the lock, by
+    // the first completion path to win. It — not status.isDone() — is the completion guard, which is what
+    // lets us complete the future *outside* the lock without a torn terminal state: a second racing
+    // callback sees terminated==true and backs off before it can decide a different result.
+    private volatile boolean terminated;
+
+    // ── Protected accessors for subclass decision logic ──────────────────────────────────────────
+
+    /**
+     * Return the current result.
+     *
+     * <p>Safe to call from any thread because the field is {@code volatile}.
+     *
+     * @return the current {@link Result}, initially {@link Result#MAYBE}
+     */
+    protected final Result getResult() {
+        return result;
+    }
+
+    /**
+     * Return whether the status future has already been completed.
+     *
+     * @return {@code true} if the evaluation has reached a terminal state
+     */
+    protected final boolean isDone() {
+        return terminated;
+    }
+
+    // ── Lock operations ───────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Run subclass decision logic under the lock.
+     *
+     * <p>The supplier may mutate subclass-owned state and must return {@code Optional.of(terminal)}
+     * to complete the evaluation or {@code Optional.empty()} to remain pending.
+     *
+     * <p>The terminal decision and the published {@code result} change together under the lock.
+     *
+     * @param decision supplier that inspects/mutates subclass state and returns the terminal
+     *                 {@link Result} wrapped in an {@link Optional}, or {@link Optional#empty()} to
+     *                 remain pending
+     */
+    protected final void decideUnderLock(Supplier<Optional<Result>> decision) {
+        Result terminal = null;
+        boolean dispatch = false;
+        lock.lock();
+        try {
+            if (!terminated) {
+                final Optional<Result> r = decision.get();
+                if (r.isPresent()) {
+                    terminal = r.get();
+                    result = terminal;  // published under lock + volatile
+                    terminated = true;  // no other callback can decide a different terminal now
+                    dispatch = true;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+        if (dispatch) {
+            publishCompletion(terminal, null);
+        }
+    }
+
+    /**
+     * Complete normally from a non-callback path (e.g., an empty rule that resolves immediately
+     * inside {@link #startEvaluation}).
+     *
+     * <p>Self-locking and guarded against races with child callbacks. Do NOT call from inside
+     * {@link #decideUnderLock} — use the supplier's return value there instead.
+     *
+     * @param r the terminal {@link Result} to publish
+     */
+    protected final void complete(Result r) {
+        boolean dispatch = false;
+        lock.lock();
+        try {
+            if (!terminated) {
+                result = r;
+                terminated = true;
+                dispatch = true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        if (dispatch) {
+            publishCompletion(r, null);
+        }
+    }
+
+    /**
+     * Complete exceptionally.
+     *
+     * <p>Publishes {@link Result#FAILED} before the future resolves.
+     *
+     * @param t the throwable that caused the failure
+     */
+    protected final void completeExceptionally(Throwable t) {
+        boolean dispatch = false;
+        lock.lock();
+        try {
+            if (!terminated) {
+                result = Result.FAILED;
+                terminated = true;
+                dispatch = true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        if (dispatch) {
+            publishCompletion(Result.FAILED, t);
+        }
+    }
+
+    /**
+     * Dispatch {@link #afterCompletion} and then transition the status future, in that order.
+     *
+     * <p>If {@link #afterCompletion(Result, Throwable)} fails, this method still resolves the future.
+     */
+    private void publishCompletion(Result completedResult, Throwable throwable) {
+        try {
+            afterCompletion(completedResult, throwable);
+        } catch (Throwable callbackFailure) {
+            if (throwable != null) {
+                if (callbackFailure != throwable) {
+                    throwable.addSuppressed(callbackFailure);
+                }
+                status.completeExceptionally(throwable);
+            } else {
+                status.completeExceptionally(callbackFailure);
+            }
+            return;
+        }
+        if (throwable != null) {
+            status.completeExceptionally(throwable);
+            return;
+        }
+        status.complete(completedResult);
+    }
+
+    /**
+     * Read subclass-owned state under the same lock used for mutations.
+     *
+     * <p>Subclasses should call this from {@link #snapshot()} to copy the fields they own into
+     * locals, then build the {@link RuleResult} outside the lock.
+     *
+     * @param <T>      the type of value to read
+     * @param supplier reads and returns the subclass-owned state
+     *
+     * @return the value returned by {@code supplier}
+     */
+    protected final <T> T readLocked(Supplier<T> supplier) {
+        lock.lock();
+        try {
+            return supplier.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // ── Template methods ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Called exactly once on the first {@link #status()} call. Subclasses kick off child evaluations
+     * and attach callbacks here.
+     *
+     * <p>Subclasses must publish any mutable state that is later read from callbacks with the same
+     * visibility guarantees used elsewhere in the class.
+     */
+    protected abstract void startEvaluation();
+
+    /**
+     * Handle post-completion work after the lock has been released.
+     *
+     * <p>Called exactly once after terminal state is recorded and before the status future resolves.
+     * The default implementation is a no-op; boolean rules use this hook to dispatch
+     * {@link Action#onCompletion(Result, Throwable, RuleResult)}.
+     *
+     * @param completedResult the terminal {@link Result} the evaluation settled on
+     * @param throwable       the cause of an exceptional completion, or {@code null} on normal completion
+     */
+    protected void afterCompletion(Result completedResult, Throwable throwable) {
+    }
+
+    // ── Final implementation of the EvaluationResult contract ────────────────────────────────────
+
+    @Override
+    public final CompletableFuture<Result> status() {
+        boolean shouldStart = false;
+        lock.lock();
+        try {
+            if (!started) {
+                started = true;
+                shouldStart = true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        if (shouldStart) {
+            try {
+                startEvaluation();
+            } catch (Throwable t) {
+                completeExceptionally(t);
+            }
+        }
+        return status;
+    }
+}

--- a/src/main/java/com/adobe/abp/regola/rules/NotRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/NotRule.java
@@ -17,12 +17,14 @@ import com.adobe.abp.regola.results.RuleResult;
 import com.adobe.abp.regola.results.UnaryBooleanRuleResult;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A rule that returns the inverse result of the subrule.
+ * A NOT with no operand rule is an invalid definition (there is no sensible value to invert), so it
+ * fails fast: {@code status()} completes exceptionally and {@code snapshot()} reports {@link Result#FAILED}.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@SuppressWarnings("this-escape")
 public class NotRule extends UnaryBooleanRule {
 
     public NotRule() {
@@ -36,64 +38,67 @@ public class NotRule extends UnaryBooleanRule {
 
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
-        return new EvaluationResult() {
+        return new LockingEvaluationResult() {
 
-            private Result result = Result.MAYBE;
-            private final CompletableFuture<Result> status = new CompletableFuture<>();
-            private EvaluationResult notResult;
+            // The evaluated operand, published once in startEvaluation() before its callback is wired up.
+            private volatile EvaluationResult notResult;
+
+            @Override
+            protected void startEvaluation() {
+                final Rule rule = getRule();
+                if (rule == null) {
+                    // A missing operand is malformed configuration, not an empty-operand identity case.
+                    completeExceptionally(new IllegalStateException("NOT rule requires a non-null operand rule"));
+                    return;
+                }
+
+                final EvaluationResult evaluationResult = rule.evaluate(factsResolver);
+                notResult = evaluationResult; // safe publication before the callback below can fire
+
+                final boolean ignore = rule.isIgnore();
+                evaluationResult.status()
+                        .whenComplete((subresult, throwable) -> evaluateSubresult(subresult, throwable, ignore));
+            }
+
+            private void evaluateSubresult(Result subresult, Throwable throwable, boolean ignore) {
+                if (!ignore && throwable != null) {
+                    // completeExceptionally() publishes Result.FAILED before the future transitions,
+                    // fixing the original ordering bug where a callback could observe MAYBE instead of FAILED.
+                    completeExceptionally(throwable);
+                    return;
+                }
+                decideUnderLock(() -> {
+                    if (ignore) {
+                        return Optional.of(Result.VALID); // an ignored subrule ⇒ VALID regardless of its result
+                    } else if (subresult == Result.VALID) {
+                        return Optional.of(Result.INVALID);
+                    } else if (subresult == Result.INVALID) {
+                        return Optional.of(Result.VALID);
+                    }
+                    // FAILED / OPERATION_NOT_SUPPORTED / MAYBE pass through unchanged
+                    return Optional.of(subresult);
+                });
+            }
+
+            @Override
+            protected void afterCompletion(Result completedResult, Throwable throwable) {
+                Optional.ofNullable(getAction())
+                        .ifPresent(action -> action.onCompletion(completedResult, throwable, snapshot()));
+            }
 
             @Override
             public RuleResult snapshot() {
+                final EvaluationResult capturedNotResult = notResult;
+                final Result capturedResult = getResult();
                 return UnaryBooleanRuleResult.builder().with(r -> {
                     r.type = getType();
                     r.description = getDescription();
-                    r.result = result;
-                    r.rule = Optional.ofNullable(notResult)
+                    r.result = capturedResult;
+                    r.rule = Optional.ofNullable(capturedNotResult)
                             .map(EvaluationResult::snapshot)
                             .orElse(null);
                     r.ignored = isIgnore();
                 }).build();
-            }
-
-            @Override
-            public CompletableFuture<Result> status() {
-                notResult = Optional.ofNullable(getRule())
-                        .map(this::evaluateRule)
-                        .orElse(null);
-                return status
-                        .whenComplete((result, throwable) -> Optional.ofNullable(getAction())
-                                .ifPresent(action -> action.onCompletion(result, throwable, snapshot())));
-            }
-
-            private EvaluationResult evaluateRule(Rule rule) {
-                final var evaluationResult = rule.evaluate(factsResolver);
-                evaluationResult.status()
-                        .whenComplete((result, throwable) -> evaluateSubresult(result, throwable, rule.isIgnore()));
-                return evaluationResult;
-            }
-
-            private synchronized void evaluateSubresult(Result subresult, Throwable throwable, boolean ignore) {
-                if (!status.isDone()) {
-                    if (!ignore && throwable != null) {
-                        status.completeExceptionally(throwable);
-                        result = Result.FAILED;
-                    } else if (ignore) {
-                        // Whatever the subresult, mark this as VALID
-                        result = Result.VALID;
-                        status.complete(result);
-                    } else if (subresult == Result.FAILED ||
-                            subresult == Result.OPERATION_NOT_SUPPORTED ||
-                            subresult == Result.MAYBE) {
-                        result = subresult;
-                        status.complete(result);
-                    } else if (subresult == Result.VALID) {
-                        result = Result.INVALID;
-                        status.complete(result);
-                    } else if (subresult == Result.INVALID) {
-                        result = Result.VALID;
-                        status.complete(result);
-                    }
-                }
             }
         };
     }

--- a/src/main/java/com/adobe/abp/regola/rules/NullRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/NullRule.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executor;
  * A rule that checks if a fact is null.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@SuppressWarnings("this-escape")
 public class NullRule extends KeyBasedRule {
 
     private final Executor executor;

--- a/src/main/java/com/adobe/abp/regola/rules/NumberRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/NumberRule.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
  *
  * @param <V> the {@link Number} type of the fact
  */
+@SuppressWarnings("this-escape")
 public class NumberRule<V extends Number & Comparable<V>> extends SingleValueRule<V> {
 
     private final Comparator<V> comparator = new NumberComparator<>();

--- a/src/main/java/com/adobe/abp/regola/rules/OrRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/OrRule.java
@@ -18,16 +18,16 @@ import com.adobe.abp.regola.results.RuleResult;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
  * This rule evaluates to true if at least one of its subrules evaluates to true.
  * If a subrule is ignored, it is not considered in the evaluation.
  * Short-circuiting: as soon as one of the subrules evaluates to VALID, the evaluation stops and the result is VALID.
+ * An empty OR has no operand able to satisfy the disjunction, so it evaluates to INVALID (the identity element).
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@SuppressWarnings("this-escape")
 public class OrRule extends MultiaryBooleanRule {
 
     public OrRule() {
@@ -41,78 +41,91 @@ public class OrRule extends MultiaryBooleanRule {
 
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
-        return new EvaluationResult() {
+        return new LockingEvaluationResult() {
 
             // Priority of the results based on their position in this list.
             // First entries have higher priority.
             // So, for example INVALID || FAILED == FAILED
             private final List<Result> RESULT_PRIORITY = List.of(Result.VALID, Result.FAILED, Result.OPERATION_NOT_SUPPORTED, Result.INVALID, Result.MAYBE);
 
-            private Result result = Result.MAYBE;
+            // The following mutable fields are accessed only inside decideUnderLock (under the lock).
             private Result intermediateResult = RESULT_PRIORITY.get(RESULT_PRIORITY.size() - 1); // Result with least priority
-            private final AtomicInteger ignoredRulesCounter = new AtomicInteger();
-            private final CompletableFuture<Result> status = new CompletableFuture<>();
-            private final AtomicInteger rulesToEvaluate = new AtomicInteger(getRules().size());
-            private List<EvaluationResult> results = List.of();
+            private int ignoredRulesCounter;
+            private int rulesToEvaluate = getRules().size();
+
+            // Child results, published once in startEvaluation() before any callback is wired up.
+            private volatile List<EvaluationResult> results = List.of();
 
             @Override
-            public RuleResult snapshot() {
-                return MultiaryBooleanRuleResult.builder().with(r -> {
-                    r.type = getType();
-                    r.description = getDescription();
-                    r.result = result;
-                    r.rules = results.stream()
-                            .map(EvaluationResult::snapshot)
-                            .collect(Collectors.toSet());
-                    r.ignored = isIgnore();
-                }).build();
-            }
-
-            @Override
-            public CompletableFuture<Result> status() {
-                results = getRules().stream()
-                        .map(this::evaluateRule)
+            protected void startEvaluation() {
+                final List<Rule> rules = getRules();
+                final List<EvaluationResult> evaluated = rules.stream()
+                        .map(rule -> rule.evaluate(factsResolver))
                         .collect(Collectors.toList());
-                return status
-                        .whenComplete((result, throwable) -> Optional.ofNullable(getAction())
-                                .ifPresent(action -> action.onCompletion(result, throwable, snapshot())));
-            }
+                results = evaluated; // safe publication before the callbacks below can fire
 
-            private EvaluationResult evaluateRule(Rule rule) {
-                final var evaluationResult = rule.evaluate(factsResolver);
-                evaluationResult.status()
-                        .whenComplete((result, throwable) -> evaluateSubresult(result, throwable, rule.isIgnore()));
-                return evaluationResult;
-            }
-
-            private synchronized void evaluateSubresult(Result subresult, Throwable throwable, boolean ignore) {
-                final var remaining = rulesToEvaluate.decrementAndGet();
-                if (ignore) {
-                    ignoredRulesCounter.incrementAndGet();
+                if (rules.isEmpty()) {
+                    complete(Result.INVALID); // empty disjunction is the identity ⇒ INVALID
+                    return;
                 }
-                if (!status.isDone()) {
-                    if (!ignore && throwable != null) {
-                        result = Result.FAILED;
-                        status.completeExceptionally(throwable);
+
+                // Non-blocking: status() kicks off each subrule and whenComplete only registers a callback,
+                // so the subrules evaluate concurrently. Each callback reports back via evaluateSubresult as
+                // it settles; this loop does not wait. (Actual concurrency depends on the fact fetchers being async.)
+                for (int i = 0; i < rules.size(); i++) {
+                    final boolean ignore = rules.get(i).isIgnore();
+                    evaluated.get(i).status()
+                            .whenComplete((subresult, throwable) -> evaluateSubresult(subresult, throwable, ignore));
+                }
+            }
+
+            private void evaluateSubresult(Result subresult, Throwable throwable, boolean ignore) {
+                if (!ignore && throwable != null) {
+                    completeExceptionally(throwable);
+                    return;
+                }
+                decideUnderLock(() -> {
+                    rulesToEvaluate--;
+                    if (ignore) {
+                        ignoredRulesCounter++;
                     } else {
-                        intermediateResult = ignore ? intermediateResult : determineResult(intermediateResult, subresult);
-                        if (intermediateResult == Result.VALID) {
-                            result = intermediateResult;
-                            status.complete(result);
-                        } else if (remaining == 0) {
-                            // If all subrules have been ignored, then default to VALID, otherwise
-                            // return the intermediate result
-                            result = ignoredRulesCounter.get() == getRules().size() ? Result.VALID : intermediateResult;
-                            status.complete(result);
-                        }
+                        intermediateResult = determineResult(intermediateResult, subresult);
                     }
-                }
+                    if (intermediateResult == Result.VALID) {
+                        return Optional.of(Result.VALID); // short-circuit: a VALID subrule satisfies the OR
+                    } else if (rulesToEvaluate == 0) {
+                        // If all subrules were ignored default to VALID, otherwise return the intermediate result
+                        return Optional.of(ignoredRulesCounter == getRules().size() ? Result.VALID : intermediateResult);
+                    }
+                    return Optional.empty();
+                });
             }
 
             // Return the result with the higher priority
             private Result determineResult(Result intermediateResult, Result result) {
                 return RESULT_PRIORITY.indexOf(result) < RESULT_PRIORITY.indexOf(intermediateResult) ?
                         result : intermediateResult;
+            }
+
+            @Override
+            protected void afterCompletion(Result completedResult, Throwable throwable) {
+                Optional.ofNullable(getAction())
+                        .ifPresent(action -> action.onCompletion(completedResult, throwable, snapshot()));
+            }
+
+            @Override
+            public RuleResult snapshot() {
+                final List<EvaluationResult> capturedResults = results;
+                final Result capturedResult = getResult();
+                return MultiaryBooleanRuleResult.builder().with(r -> {
+                    r.type = getType();
+                    r.description = getDescription();
+                    r.result = capturedResult;
+                    r.rules = capturedResults.stream()
+                            .map(EvaluationResult::snapshot)
+                            .collect(Collectors.toSet());
+                    r.ignored = isIgnore();
+                }).build();
             }
         };
     }

--- a/src/main/java/com/adobe/abp/regola/rules/StringRule.java
+++ b/src/main/java/com/adobe/abp/regola/rules/StringRule.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * A rule that checks a String fact against a String value.
  */
+@SuppressWarnings("this-escape")
 public class StringRule extends SingleValueRule<String> {
 
     public StringRule() {

--- a/src/test/java/com/adobe/abp/regola/evaluators/EvaluatorTest.java
+++ b/src/test/java/com/adobe/abp/regola/evaluators/EvaluatorTest.java
@@ -43,7 +43,7 @@ class EvaluatorTest {
     private class MockEvaluationResult implements EvaluationResult {
 
         @Override
-        public synchronized RuleResult snapshot() {
+        public RuleResult snapshot() {
             return ruleResult;
         }
 

--- a/src/test/java/com/adobe/abp/regola/mockrules/DelayedExceptionRule.java
+++ b/src/test/java/com/adobe/abp/regola/mockrules/DelayedExceptionRule.java
@@ -19,7 +19,9 @@ import com.adobe.abp.regola.rules.EvaluationResult;
 import com.adobe.abp.regola.rules.KeyBasedRule;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
 
+@SuppressWarnings("this-escape")
 public class DelayedExceptionRule extends KeyBasedRule {
 
     private final long delayMillis;
@@ -33,16 +35,22 @@ public class DelayedExceptionRule extends KeyBasedRule {
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
         return new EvaluationResult() {
+            private final ReentrantLock lock = new ReentrantLock();
             private Result result = Result.MAYBE;
 
             @Override
-            public synchronized RuleResult snapshot() {
-                return ValuesRuleResult.builder().with(r -> {
-                    r.type = getType();
-                    r.key = getKey();
-                    r.result = result;
-                    r.ignored = isIgnore();
-                }).build();
+            public RuleResult snapshot() {
+                lock.lock();
+                try {
+                    return ValuesRuleResult.builder().with(r -> {
+                        r.type = getType();
+                        r.key = getKey();
+                        r.result = result;
+                        r.ignored = isIgnore();
+                    }).build();
+                } finally {
+                    lock.unlock();
+                }
             }
 
             @Override
@@ -50,7 +58,12 @@ public class DelayedExceptionRule extends KeyBasedRule {
                 return CompletableFuture.supplyAsync(() -> {
                     try {
                         Thread.sleep(delayMillis);
-                        result = Result.FAILED;
+                        lock.lock();
+                        try {
+                            result = Result.FAILED;
+                        } finally {
+                            lock.unlock();
+                        }
                         throw new RuntimeException("Intentionally failing this rule with an exception");
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
@@ -61,4 +74,3 @@ public class DelayedExceptionRule extends KeyBasedRule {
 
     }
 }
-

--- a/src/test/java/com/adobe/abp/regola/mockrules/DelayedRule.java
+++ b/src/test/java/com/adobe/abp/regola/mockrules/DelayedRule.java
@@ -19,7 +19,9 @@ import com.adobe.abp.regola.rules.EvaluationResult;
 import com.adobe.abp.regola.rules.KeyBasedRule;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
 
+@SuppressWarnings("this-escape")
 public class DelayedRule extends KeyBasedRule {
 
     private final Result finalResult;
@@ -35,16 +37,22 @@ public class DelayedRule extends KeyBasedRule {
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
         return new EvaluationResult() {
+            private final ReentrantLock lock = new ReentrantLock();
             private Result result = Result.MAYBE;
 
             @Override
-            public synchronized RuleResult snapshot() {
-                return ValuesRuleResult.builder().with(r -> {
-                    r.type = getType();
-                    r.key = getKey();
-                    r.result = result;
-                    r.ignored = isIgnore();
-                }).build();
+            public RuleResult snapshot() {
+                lock.lock();
+                try {
+                    return ValuesRuleResult.builder().with(r -> {
+                        r.type = getType();
+                        r.key = getKey();
+                        r.result = result;
+                        r.ignored = isIgnore();
+                    }).build();
+                } finally {
+                    lock.unlock();
+                }
             }
 
             @Override
@@ -52,8 +60,13 @@ public class DelayedRule extends KeyBasedRule {
                 return CompletableFuture.supplyAsync(() -> {
                     try {
                         Thread.sleep(delayMillis);
-                        result = finalResult;
-                        return result;
+                        lock.lock();
+                        try {
+                            result = finalResult;
+                            return result;
+                        } finally {
+                            lock.unlock();
+                        }
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
@@ -63,4 +76,3 @@ public class DelayedRule extends KeyBasedRule {
 
     }
 }
-

--- a/src/test/java/com/adobe/abp/regola/mockrules/ExceptionRule.java
+++ b/src/test/java/com/adobe/abp/regola/mockrules/ExceptionRule.java
@@ -19,7 +19,9 @@ import com.adobe.abp.regola.rules.EvaluationResult;
 import com.adobe.abp.regola.rules.KeyBasedRule;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
 
+@SuppressWarnings("this-escape")
 public class ExceptionRule extends KeyBasedRule {
 
     public ExceptionRule(String key) {
@@ -30,22 +32,33 @@ public class ExceptionRule extends KeyBasedRule {
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
         return new EvaluationResult() {
+            private final ReentrantLock lock = new ReentrantLock();
             private Result result = Result.MAYBE;
 
             @Override
-            public synchronized RuleResult snapshot() {
-                return ValuesRuleResult.builder().with(r -> {
-                    r.type = getType();
-                    r.key = getKey();
-                    r.result = result;
-                    r.ignored = isIgnore();
-                }).build();
+            public RuleResult snapshot() {
+                lock.lock();
+                try {
+                    return ValuesRuleResult.builder().with(r -> {
+                        r.type = getType();
+                        r.key = getKey();
+                        r.result = result;
+                        r.ignored = isIgnore();
+                    }).build();
+                } finally {
+                    lock.unlock();
+                }
             }
 
             @Override
             public CompletableFuture<Result> status() {
                 return CompletableFuture.supplyAsync(() -> {
-                    result = Result.FAILED;
+                    lock.lock();
+                    try {
+                        result = Result.FAILED;
+                    } finally {
+                        lock.unlock();
+                    }
                     throw new RuntimeException("Intentionally failing this rule with an exception");
                 });
             }
@@ -53,4 +66,3 @@ public class ExceptionRule extends KeyBasedRule {
 
     }
 }
-

--- a/src/test/java/com/adobe/abp/regola/mockrules/MockRule.java
+++ b/src/test/java/com/adobe/abp/regola/mockrules/MockRule.java
@@ -19,7 +19,9 @@ import com.adobe.abp.regola.rules.EvaluationResult;
 import com.adobe.abp.regola.rules.KeyBasedRule;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
 
+@SuppressWarnings("this-escape")
 public class MockRule extends KeyBasedRule {
 
     private Result finalResult;
@@ -37,23 +39,34 @@ public class MockRule extends KeyBasedRule {
     @Override
     public EvaluationResult evaluate(FactsResolver factsResolver) {
         return new EvaluationResult() {
+            private final ReentrantLock lock = new ReentrantLock();
             private Result result = Result.MAYBE;
 
             @Override
-            public synchronized RuleResult snapshot() {
-                return ValuesRuleResult.builder().with(r -> {
-                    r.type = getType();
-                    r.key = getKey();
-                    r.result = result;
-                    r.ignored = isIgnore();
-                }).build();
+            public RuleResult snapshot() {
+                lock.lock();
+                try {
+                    return ValuesRuleResult.builder().with(r -> {
+                        r.type = getType();
+                        r.key = getKey();
+                        r.result = result;
+                        r.ignored = isIgnore();
+                    }).build();
+                } finally {
+                    lock.unlock();
+                }
             }
 
             @Override
             public CompletableFuture<Result> status() {
                 return CompletableFuture.supplyAsync(() -> {
-                    result = finalResult;
-                    return result;
+                    lock.lock();
+                    try {
+                        result = finalResult;
+                        return result;
+                    } finally {
+                        lock.unlock();
+                    }
                 });
             }
         };

--- a/src/test/java/com/adobe/abp/regola/rules/AndRuleTest.java
+++ b/src/test/java/com/adobe/abp/regola/rules/AndRuleTest.java
@@ -321,6 +321,59 @@ class AndRuleTest {
     }
 
     @Nested
+    @DisplayName("with startup edge cases should")
+    class StartupEdgeCases {
+
+        @Test
+        @DisplayName("evaluate an empty AND as VALID (identity of conjunction)")
+        void emptyAndIsValid() {
+            rule.setRules(List.of());
+
+            final var evaluationResult = rule.evaluate(resolver);
+
+            assertThat(evaluationResult.snapshot().getResult()).isEqualTo(Result.MAYBE);
+
+            final var result = evaluationResult.status().join();
+
+            assertThat(result).isEqualTo(Result.VALID);
+            assertThat(evaluationResult.snapshot()).isEqualTo(buildRuleResult(ruleResultBuilder, Result.VALID));
+        }
+
+        @Test
+        @DisplayName("return the same future and not restart evaluation on repeated status() calls")
+        void repeatedStatusReturnsSameFuture() {
+            final var ruleOne = new MockRule("rule-1", Result.VALID);
+            final var ruleTwo = new MockRule("rule-2", Result.VALID);
+            rule.setRules(List.of(ruleOne, ruleTwo));
+
+            final var evaluationResult = rule.evaluate(resolver);
+            final var first = evaluationResult.status();
+            final var second = evaluationResult.status();
+
+            assertThat(first).isSameAs(second);
+            assertThat(first.join()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("fire the completion action exactly once even across repeated status() calls")
+        void actionFiresExactlyOnceAcrossRepeatedStatus() {
+            final var ruleOne = new MockRule("rule-1", Result.VALID);
+            final var ruleTwo = new MockRule("rule-2", Result.VALID);
+            rule.setRules(List.of(ruleOne, ruleTwo));
+
+            var counter = new AtomicInteger(0);
+            rule.setAction(new Action().setOnCompletion((result, throwable, ruleResult) -> counter.getAndIncrement()));
+
+            final var evaluationResult = rule.evaluate(resolver);
+            evaluationResult.status().join();
+            evaluationResult.status().join();
+            evaluationResult.status().join();
+
+            assertThat(counter.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
     @DisplayName("with delayed rules should")
     class WithDelayedRulesTest {
 

--- a/src/test/java/com/adobe/abp/regola/rules/LockingEvaluationResultTest.java
+++ b/src/test/java/com/adobe/abp/regola/rules/LockingEvaluationResultTest.java
@@ -1,0 +1,546 @@
+/*
+ *  Copyright 2026 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License
+ */
+
+package com.adobe.abp.regola.rules;
+
+import com.adobe.abp.regola.results.Result;
+import com.adobe.abp.regola.results.RuleResult;
+import java.util.Optional;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Testing LockingEvaluationResult")
+class LockingEvaluationResultTest {
+
+    // ── Minimal stub subclass used across tests ───────────────────────────────────────────────────
+
+    /**
+     * Concrete stub that owns a {@code String} label to exercise the copy-under-lock pattern in
+     * {@link #snapshot()}. The label is set inside {@link #startEvaluation()} to verify that
+     * publication-under-lock works correctly.
+     */
+    static class StubResult extends LockingEvaluationResult {
+
+        // Subclass-owned mutable state — written on the status()-calling thread inside
+        // startEvaluation(), read under readLocked() in snapshot().
+        private String label = "initial";
+        private final AtomicInteger afterCompletionCount = new AtomicInteger();
+        private final AtomicReference<Result> afterCompletionResult = new AtomicReference<>();
+        private final AtomicReference<Throwable> afterCompletionThrowable = new AtomicReference<>();
+
+        // Externally injectable start logic — lets each test drive startEvaluation differently
+        private Runnable startBehavior = () -> {};
+
+        void setStartBehavior(Runnable startBehavior) {
+            this.startBehavior = startBehavior;
+        }
+
+        @Override
+        protected void startEvaluation() {
+            startBehavior.run();
+        }
+
+        @Override
+        protected void afterCompletion(Result completedResult, Throwable throwable) {
+            afterCompletionCount.incrementAndGet();
+            afterCompletionResult.set(completedResult);
+            afterCompletionThrowable.set(throwable);
+        }
+
+        @Override
+        public RuleResult snapshot() {
+            final String capturedLabel = readLocked(() -> label);
+            final Result capturedResult = getResult();
+            final RuleResult r = new RuleResult();
+            r.setResult(capturedResult);
+            r.setType("STUB");
+            r.setMessage(capturedLabel);
+            return r;
+        }
+
+        // Exposed so tests can drive decideUnderLock from outside
+        void decide(Supplier<Optional<Result>> decision) {
+            decideUnderLock(decision);
+        }
+
+        void completeWith(Result r) {
+            complete(r);
+        }
+
+        void completeWithException(Throwable t) {
+            completeExceptionally(t);
+        }
+
+        void setLabel(String value) {
+            this.label = value;
+        }
+    }
+
+    private Supplier<Optional<Result>> returning(Result r) {
+        return () -> Optional.of(r);
+    }
+
+    private Supplier<Optional<Result>> pending() {
+        return Optional::empty;
+    }
+
+    // ── One-time startup ──────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("one-time startup")
+    class OneTimeStartup {
+
+        @Test
+        @DisplayName("status() returns the same CompletableFuture on repeated calls")
+        void repeatedStatusReturnsSameFuture() {
+            final var stub = new StubResult();
+            stub.setStartBehavior(() -> stub.completeWith(Result.VALID));
+
+            final var first = stub.status();
+            final var second = stub.status();
+            final var third = stub.status();
+
+            assertThat(first).isSameAs(second);
+            assertThat(first).isSameAs(third);
+        }
+
+        @Test
+        @DisplayName("startEvaluation is invoked exactly once across repeated status() calls")
+        void startEvaluationCalledOnce() {
+            final var callCount = new AtomicInteger();
+            final var stub = new StubResult();
+            stub.setStartBehavior(() -> {
+                callCount.incrementAndGet();
+                stub.completeWith(Result.VALID);
+            });
+
+            stub.status();
+            stub.status();
+            stub.status();
+
+            assertThat(callCount.get()).isEqualTo(1);
+        }
+    }
+
+    // ── decideUnderLock mutual exclusion ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("decideUnderLock")
+    class DecideUnderLock {
+
+        @Test
+        @DisplayName("pending decision does not complete the future")
+        void pendingDecisionDoesNotComplete() {
+            final var stub = new StubResult();
+            stub.status(); // start (no-op startBehavior)
+
+            stub.decide(pending());
+
+            assertThat(stub.isDone()).isFalse();
+        }
+
+        @Test
+        @DisplayName("terminal decision completes the future with the given result")
+        void terminalDecisionCompletesFuture() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.decide(returning(Result.VALID));
+
+            assertThat(stub.status().join()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("second terminal decision after first is already done is ignored")
+        void secondDecisionIgnoredAfterCompletion() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.decide(returning(Result.VALID));
+            stub.decide(returning(Result.INVALID));
+
+            assertThat(stub.status().join()).isEqualTo(Result.VALID);
+        }
+
+        /**
+         * Torn-state regression: spin up COMPETITOR_COUNT threads, each racing to settle the future
+         * with a *different* terminal Result. After all threads finish, the snapshot result must
+         * equal whatever result the future settled to — they must never diverge.
+         */
+        @RepeatedTest(200)
+        @DisplayName("concurrent competing decisions never produce a torn terminal state")
+        void concurrentDecisionsNoTornState() throws InterruptedException {
+            final int competitorCount = 4;
+            final var stub = new StubResult();
+            stub.status(); // start (no-op)
+
+            final Result[] candidates = {Result.VALID, Result.INVALID, Result.FAILED, Result.OPERATION_NOT_SUPPORTED};
+            final var barrier = new CyclicBarrier(competitorCount);
+            final var executor = Executors.newFixedThreadPool(competitorCount);
+
+            for (int i = 0; i < competitorCount; i++) {
+                final Result candidate = candidates[i];
+                executor.submit(() -> {
+                    try {
+                        barrier.await(); // synchronize all threads to maximize contention
+                    } catch (InterruptedException | BrokenBarrierException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    stub.decide(returning(candidate));
+                });
+            }
+
+            executor.shutdown();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+            final Result futureResult = stub.status().join();
+            final Result snapshotResult = stub.snapshot().getResult();
+
+            assertThat(snapshotResult)
+                    .as("snapshot result must equal future result — torn state detected")
+                    .isEqualTo(futureResult);
+        }
+    }
+
+    // ── complete() ───────────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("complete()")
+    class CompleteMethod {
+
+        @Test
+        @DisplayName("completes future with given result")
+        void completesFuture() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.completeWith(Result.VALID);
+
+            assertThat(stub.status().join()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("is idempotent — second call does not change the settled result")
+        void idempotent() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.completeWith(Result.VALID);
+            stub.completeWith(Result.INVALID);
+
+            assertThat(stub.status().join()).isEqualTo(Result.VALID);
+        }
+    }
+
+    // ── completeExceptionally() ───────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("completeExceptionally()")
+    class CompleteExceptionally {
+
+        @Test
+        @DisplayName("always sets Result.FAILED before transitioning the future")
+        void alwaysSetsFailed() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.completeWithException(new RuntimeException("boom"));
+
+            assertThat(stub.snapshot().getResult()).isEqualTo(Result.FAILED);
+        }
+
+        @Test
+        @DisplayName("future is completed exceptionally")
+        void futureCompletedExceptionally() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.completeWithException(new RuntimeException("boom"));
+
+            assertThat(stub.status()).isCompletedExceptionally();
+        }
+
+        @Test
+        @DisplayName("snapshot reflects FAILED before the future's whenComplete callback fires")
+        void snapshotReflectsFailedAtCallbackTime() {
+            final var stub = new StubResult();
+            final AtomicReference<Result> resultAtCallback = new AtomicReference<>();
+
+            stub.status().whenComplete((r, t) -> resultAtCallback.set(stub.snapshot().getResult()));
+            stub.completeWithException(new RuntimeException("test"));
+
+            // status().join() would throw; just check the callback observed FAILED
+            assertThat(resultAtCallback.get()).isEqualTo(Result.FAILED);
+        }
+    }
+
+    // ── readLocked() / snapshot copy-under-lock ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("readLocked()")
+    class ReadLocked {
+
+        @Test
+        @DisplayName("snapshot copies subclass-owned state under the lock")
+        void snapshotCopiesStateUnderLock() {
+            final var stub = new StubResult();
+            stub.setStartBehavior(() -> {
+                stub.setLabel("evaluation-started");
+                stub.completeWith(Result.VALID);
+            });
+
+            stub.status().join();
+
+            assertThat(stub.snapshot().getMessage()).isEqualTo("evaluation-started");
+        }
+    }
+
+    // ── afterCompletion dispatch ──────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("afterCompletion")
+    class AfterCompletion {
+
+        @Test
+        @DisplayName("fires exactly once on normal completion")
+        void firesOnceNormalCompletion() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.completeWith(Result.VALID);
+
+            assertThat(stub.afterCompletionCount.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("fires exactly once on exceptional completion")
+        void firesOnceExceptionalCompletion() {
+            final var stub = new StubResult();
+            stub.status();
+
+            stub.completeWithException(new RuntimeException());
+
+            assertThat(stub.afterCompletionCount.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("does not fire a second time when status() is called again after completion")
+        void doesNotFireAgainOnRepeatedStatus() {
+            final var stub = new StubResult();
+            stub.status();
+            stub.completeWith(Result.VALID);
+
+            stub.status();
+            stub.status();
+
+            assertThat(stub.afterCompletionCount.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("receives the terminal result on normal completion")
+        void receivesTerminalResult() {
+            final var stub = new StubResult();
+            stub.status();
+            stub.completeWith(Result.INVALID);
+
+            assertThat(stub.afterCompletionResult.get()).isEqualTo(Result.INVALID);
+        }
+
+        @Test
+        @DisplayName("receives FAILED and throwable on exceptional completion")
+        void receivesFailedAndThrowable() {
+            final var stub = new StubResult();
+            final var cause = new RuntimeException("test");
+            stub.status();
+
+            stub.completeWithException(cause);
+
+            assertThat(stub.afterCompletionResult.get()).isEqualTo(Result.FAILED);
+            assertThat(stub.afterCompletionThrowable.get()).isSameAs(cause);
+        }
+
+        @Test
+        @DisplayName("completes exceptionally when afterCompletion throws after normal completion")
+        void callbackFailureSettlesNormalCompletion() {
+            final var callbackFailure = new IllegalStateException("callback failed");
+            final var stub = new StubResult() {
+                @Override
+                protected void afterCompletion(Result completedResult, Throwable throwable) {
+                    super.afterCompletion(completedResult, throwable);
+                    throw callbackFailure;
+                }
+            };
+
+            stub.status();
+            stub.completeWith(Result.VALID);
+
+            assertThat(stub.status()).isCompletedExceptionally();
+            assertThatThrownBy(() -> stub.status().join())
+                    .hasCause(callbackFailure);
+            assertThat(stub.snapshot().getResult()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("preserves the original failure when afterCompletion also throws")
+        void callbackFailureDoesNotReplaceExceptionalCompletion() {
+            final var cause = new RuntimeException("evaluation failed");
+            final var callbackFailure = new IllegalStateException("callback failed");
+            final var stub = new StubResult() {
+                @Override
+                protected void afterCompletion(Result completedResult, Throwable throwable) {
+                    super.afterCompletion(completedResult, throwable);
+                    throw callbackFailure;
+                }
+            };
+
+            stub.status();
+            stub.completeWithException(cause);
+
+            assertThat(stub.status()).isCompletedExceptionally();
+            assertThatThrownBy(() -> stub.status().join())
+                    .hasCause(cause);
+            assertThat(cause.getSuppressed()).containsExactly(callbackFailure);
+            assertThat(stub.snapshot().getResult()).isEqualTo(Result.FAILED);
+        }
+
+        @Test
+        @DisplayName("completes exceptionally when afterCompletion rethrows the original failure")
+        void callbackRethrowsOriginalFailure() {
+            final var cause = new RuntimeException("evaluation failed");
+            final var stub = new StubResult() {
+                @Override
+                protected void afterCompletion(Result completedResult, Throwable throwable) {
+                    super.afterCompletion(completedResult, throwable);
+                    throw (RuntimeException) throwable;
+                }
+            };
+
+            stub.status();
+            stub.completeWithException(cause);
+
+            assertThat(stub.status()).isCompletedExceptionally();
+            assertThatThrownBy(() -> stub.status().join())
+                    .hasCause(cause);
+            assertThat(cause.getSuppressed()).isEmpty();
+            assertThat(stub.snapshot().getResult()).isEqualTo(Result.FAILED);
+        }
+
+        @Test
+        @DisplayName("does not hold the internal lock when afterCompletion is called")
+        void notCalledUnderLock() throws InterruptedException {
+            // We verify that another thread can call readLocked() while afterCompletion is running.
+            // If afterCompletion were called under the lock, the readLocked() call below would deadlock
+            // (ReentrantLock is reentrant for the *same* thread, but not for other threads).
+            final var lockAccessibleDuringCallback = new CountDownLatch(1);
+            final var stub = new StubResult() {
+                @Override
+                protected void afterCompletion(Result completedResult, Throwable throwable) {
+                    super.afterCompletion(completedResult, throwable);
+                    // Spawn a separate thread that tries to acquire the lock via readLocked.
+                    // If the lock were held here, this would block.
+                    final var future = CompletableFuture.runAsync(() ->
+                            readLocked(() -> {
+                                lockAccessibleDuringCallback.countDown();
+                                return null;
+                            })
+                    );
+                    try {
+                        future.get(2, TimeUnit.SECONDS);
+                    } catch (Exception e) {
+                        // Do not decrement latch — test will fail on assertion below
+                    }
+                }
+            };
+
+            stub.status();
+            stub.completeWith(Result.VALID);
+
+            assertThat(lockAccessibleDuringCallback.await(3, TimeUnit.SECONDS))
+                    .as("lock must not be held during afterCompletion — another thread could not acquire it")
+                    .isTrue();
+        }
+    }
+
+    // ── startEvaluation() failure ─────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("startEvaluation failure")
+    class StartEvaluationFailure {
+
+        @Test
+        @DisplayName("future is completed exceptionally if startEvaluation throws")
+        void futureCompletedWhenStartThrows() {
+            final var stub = new StubResult();
+            stub.setStartBehavior(() -> { throw new IllegalStateException("start failed"); });
+
+            stub.status();
+
+            assertThat(stub.status()).isCompletedExceptionally();
+        }
+
+        @Test
+        @DisplayName("snapshot reflects FAILED if startEvaluation throws")
+        void snapshotFailedWhenStartThrows() {
+            final var stub = new StubResult();
+            stub.setStartBehavior(() -> { throw new IllegalStateException("start failed"); });
+
+            stub.status();
+
+            assertThat(stub.snapshot().getResult()).isEqualTo(Result.FAILED);
+        }
+    }
+
+    // ── publication ordering ──────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("publication ordering")
+    class PublicationOrdering {
+
+        @Test
+        @DisplayName("snapshot reflects terminal result when whenComplete callback fires (normal)")
+        void snapshotTerminalAtNormalCompletion() {
+            final var stub = new StubResult();
+            final AtomicReference<Result> resultAtCallback = new AtomicReference<>();
+
+            stub.status().whenComplete((r, t) -> resultAtCallback.set(stub.snapshot().getResult()));
+            stub.completeWith(Result.VALID);
+
+            assertThat(resultAtCallback.get()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("snapshot reflects FAILED when whenComplete callback fires (exceptional)")
+        void snapshotFailedAtExceptionalCompletion() {
+            final var stub = new StubResult();
+            final AtomicReference<Result> resultAtCallback = new AtomicReference<>();
+
+            stub.status().whenComplete((r, t) -> resultAtCallback.set(stub.snapshot().getResult()));
+            stub.completeWithException(new RuntimeException("oops"));
+
+            assertThat(resultAtCallback.get()).isEqualTo(Result.FAILED);
+        }
+    }
+}

--- a/src/test/java/com/adobe/abp/regola/rules/NotRuleTest.java
+++ b/src/test/java/com/adobe/abp/regola/rules/NotRuleTest.java
@@ -20,6 +20,7 @@ import com.adobe.abp.regola.results.Result;
 import com.adobe.abp.regola.results.RuleResult;
 import com.adobe.abp.regola.results.UnaryBooleanRuleResult;
 import com.adobe.abp.regola.results.ValuesRuleResult;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 @DisplayName("Testing NotRule")
@@ -205,6 +207,60 @@ class NotRuleTest {
     }
 
     @Nested
+    @DisplayName("with startup edge cases should")
+    class StartupEdgeCases {
+
+        @Test
+        @DisplayName("fail fast (not hang) when the operand rule is missing")
+        void missingOperandFailsFast() {
+            // no rule.setRule(...) → getRule() is null
+
+            final var evaluationResult = rule.evaluate(resolver);
+
+            assertThat(evaluationResult.snapshot().getResult()).isEqualTo(Result.MAYBE);
+
+            final var status = evaluationResult.status();
+            assertThat(status).failsWithin(Duration.ofMillis(50)); // proves it does not hang
+            assertThatThrownBy(status::join)
+                    .isInstanceOf(CompletionException.class)
+                    .hasRootCauseInstanceOf(IllegalStateException.class);
+
+            assertThat(evaluationResult.snapshot().getResult()).isEqualTo(Result.FAILED);
+        }
+
+        @Test
+        @DisplayName("return the same future and not restart evaluation on repeated status() calls")
+        void repeatedStatusReturnsSameFuture() {
+            final var subrule = new MockRule("subrule", Result.INVALID);
+            rule.setRule(subrule);
+
+            final var evaluationResult = rule.evaluate(resolver);
+            final var first = evaluationResult.status();
+            final var second = evaluationResult.status();
+
+            assertThat(first).isSameAs(second);
+            assertThat(first.join()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("fire the completion action exactly once even across repeated status() calls")
+        void actionFiresExactlyOnceAcrossRepeatedStatus() {
+            final var subrule = new MockRule("subrule", Result.INVALID);
+            rule.setRule(subrule);
+
+            var counter = new AtomicInteger(0);
+            rule.setAction(new Action().setOnCompletion((result, throwable, ruleResult) -> counter.getAndIncrement()));
+
+            final var evaluationResult = rule.evaluate(resolver);
+            evaluationResult.status().join();
+            evaluationResult.status().join();
+            evaluationResult.status().join();
+
+            assertThat(counter.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
     @DisplayName("with delayed rule should")
     class WithDelayedRuleTest {
 
@@ -251,6 +307,25 @@ class NotRuleTest {
                             ruleResult -> assertThat(ruleResult.getRule())
                                     .extracting(RuleResult::getType, RuleResult::getResult)
                                     .containsExactly("EXCEPTION_RULE", Result.FAILED));
+        }
+
+        @Test
+        @DisplayName("expose FAILED (not MAYBE) from a completion callback when the subrule throws")
+        void snapshotReflectsFailedFromCompletionCallback() {
+            final var subrule = new ExceptionRule("rule-2");
+            rule.setRule(subrule);
+
+            final var evaluationResult = rule.evaluate(resolver);
+            final var resultAtCallback = new AtomicReference<Result>();
+
+            // The probe future completes only after our whenComplete callback has run, so observing
+            // its completion guarantees the callback ran — no race on reading resultAtCallback.
+            final var probe = evaluationResult.status()
+                    .whenComplete((r, t) -> resultAtCallback.set(evaluationResult.snapshot().getResult()));
+
+            assertThat(probe).failsWithin(Duration.ofMillis(50));
+
+            assertThat(resultAtCallback.get()).isEqualTo(Result.FAILED);
         }
 
         @Test

--- a/src/test/java/com/adobe/abp/regola/rules/OrRuleTest.java
+++ b/src/test/java/com/adobe/abp/regola/rules/OrRuleTest.java
@@ -396,6 +396,59 @@ class OrRuleTest {
     }
 
     @Nested
+    @DisplayName("with startup edge cases should")
+    class StartupEdgeCases {
+
+        @Test
+        @DisplayName("evaluate an empty OR as INVALID (identity of disjunction)")
+        void emptyOrIsInvalid() {
+            rule.setRules(List.of());
+
+            final var evaluationResult = rule.evaluate(resolver);
+
+            assertThat(evaluationResult.snapshot().getResult()).isEqualTo(Result.MAYBE);
+
+            final var result = evaluationResult.status().join();
+
+            assertThat(result).isEqualTo(Result.INVALID);
+            assertThat(evaluationResult.snapshot()).isEqualTo(buildRuleResult(ruleResultBuilder, Result.INVALID));
+        }
+
+        @Test
+        @DisplayName("return the same future and not restart evaluation on repeated status() calls")
+        void repeatedStatusReturnsSameFuture() {
+            final var ruleOne = new MockRule("rule-1", Result.VALID);
+            final var ruleTwo = new MockRule("rule-2", Result.INVALID);
+            rule.setRules(List.of(ruleOne, ruleTwo));
+
+            final var evaluationResult = rule.evaluate(resolver);
+            final var first = evaluationResult.status();
+            final var second = evaluationResult.status();
+
+            assertThat(first).isSameAs(second);
+            assertThat(first.join()).isEqualTo(Result.VALID);
+        }
+
+        @Test
+        @DisplayName("fire the completion action exactly once even across repeated status() calls")
+        void actionFiresExactlyOnceAcrossRepeatedStatus() {
+            final var ruleOne = new MockRule("rule-1", Result.VALID);
+            final var ruleTwo = new MockRule("rule-2", Result.INVALID);
+            rule.setRules(List.of(ruleOne, ruleTwo));
+
+            var counter = new AtomicInteger(0);
+            rule.setAction(new Action().setOnCompletion((result, throwable, ruleResult) -> counter.getAndIncrement()));
+
+            final var evaluationResult = rule.evaluate(resolver);
+            evaluationResult.status().join();
+            evaluationResult.status().join();
+            evaluationResult.status().join();
+
+            assertThat(counter.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
     @DisplayName("with delayed rules should")
     class WithDelayedRulesTest {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces `LockingEvaluationResult`, a shared base for evaluation results that need thread-safe state transitions when multiple async callbacks can complete concurrently. `AndRule`, `OrRule`, and `NotRule` now use this implementation so their  terminal result, snapshot state, and completion callbacks stay consistent even under races.

It also makes the behaviour of boolean composite rules explicit for edge cases that were previously subtle or underspecified. 
Empty AND now resolves to VALID, empty OR resolves to INVALID, NOT with a missing operand fails fast.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This will allow for a better transition to Java 21 and up, especially when wanting to leverage virtual threads.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Yes. Unit tests. 

Run changes against JDK 11 and JDK 21.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
