### PR TITLE
Fix flaky tests in DataFetcherTest when JVM running slow

### DIFF
--- a/src/test/java/com/adobe/abp/regola/datafetchers/DataFetcherTest.java
+++ b/src/test/java/com/adobe/abp/regola/datafetchers/DataFetcherTest.java
@@ -195,7 +195,7 @@ class DataFetcherTest {
                 final var dataFetcher = new FixedDelayedDataFetcherWithLogging(20, 10, false);
 
                 assertThat(dataFetcher.fetch(context))
-                        .succeedsWithin(Duration.ofMillis(100));
+                        .succeedsWithin(Duration.ofMillis(500));
             }
 
             // This test is used to verify that logging is taking place. No proper assertions are put in place.
@@ -205,7 +205,7 @@ class DataFetcherTest {
                 final var dataFetcher = new FixedDelayedDataFetcherWithLogging(20, 50, true);
 
                 assertThat(dataFetcher.fetch(context))
-                        .failsWithin(Duration.ofMillis(100))
+                        .failsWithin(Duration.ofMillis(500))
                         .withThrowableOfType(ExecutionException.class)
                         .withCauseInstanceOf(RuntimeException.class)
                         .withMessageContaining("Exception thrown during a test");
@@ -223,7 +223,7 @@ class DataFetcherTest {
                 final var dataFetcher = new FixedDelayedDataFetcherWithLogging(agent, 20, 50, false);
 
                 assertThat(dataFetcher.fetch(context))
-                        .succeedsWithin(Duration.ofMillis(100));
+                        .succeedsWithin(Duration.ofMillis(500));
 
                 verify(agent).onSuccess(eq("FixedDelayedDataFetcherWithLogging"), anyString(), anyLong());
                 verify(agent, never()).onSlaBreach(anyString(), anyString(), anyLong(), anyDouble());
@@ -236,7 +236,7 @@ class DataFetcherTest {
                 final var dataFetcher = new FixedDelayedDataFetcherWithLogging(agent, 20, 10, false);
 
                 assertThat(dataFetcher.fetch(context))
-                        .succeedsWithin(Duration.ofMillis(100));
+                        .succeedsWithin(Duration.ofMillis(500));
 
                 verify(agent).onSuccess(eq("FixedDelayedDataFetcherWithLogging"), anyString(), anyLong());
                 verify(agent).onSlaBreach(eq("FixedDelayedDataFetcherWithLogging"), anyString(), eq(10L), anyDouble());
@@ -249,7 +249,7 @@ class DataFetcherTest {
                 final var dataFetcher = new FixedDelayedDataFetcherWithLogging(agent, 20, 50, true);
 
                 assertThat(dataFetcher.fetch(context))
-                        .failsWithin(Duration.ofMillis(100));
+                        .failsWithin(Duration.ofMillis(500));
 
                 verify(agent, never()).onSuccess(anyString(), anyString(), anyLong());
                 verify(agent, never()).onSlaBreach(anyString(), anyString(), anyLong(), anyDouble());
@@ -265,7 +265,7 @@ class DataFetcherTest {
                 final var dataFetcher = new FixedDelayedDataFetcherWithLogging(agent, 20, 50, true);
 
                 assertThat(dataFetcher.fetch(context))
-                        .failsWithin(Duration.ofMillis(100)); // CompletableFuture is completed with failure.
+                        .failsWithin(Duration.ofMillis(500)); // CompletableFuture is completed with failure.
 
                 verify(agent, never()).onSuccess(anyString(), anyString(), anyLong());
                 verify(agent, never()).onSlaBreach(anyString(), anyString(), anyLong(), anyDouble());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix flaky tests in DataFetcherTest when JVM running slow
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Pipeline occasionally failing due to JVM running slow and test not able to complete on time.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
